### PR TITLE
Fix Issue with staticnat and CloudStack 4.5: NameError: global name '…

### DIFF
--- a/cs_staticnat.py
+++ b/cs_staticnat.py
@@ -522,7 +522,7 @@ class AnsibleCloudStack(object):
 class AnsibleCloudStackStaticNat(AnsibleCloudStack):
 
     def __init__(self, module):
-        super(AnsibleCloudStackPortforwarding, self).__init__(module)
+        super(AnsibleCloudStackStaticNat, self).__init__(module)
         self.returns = {
             'virtualmachinedisplayname':    'vm_display_name',
             'virtualmachinename':           'vm_name',


### PR DESCRIPTION
…AnsibleCloudStackPortforwarding' is not defined

https://github.com/resmo/ansible-cloudstack/issues/28
