### PR TITLE
Fix the issue cs_firewall fails when multiple zones exist

### DIFF
--- a/cs_firewall.py
+++ b/cs_firewall.py
@@ -99,6 +99,12 @@ options:
       - Name of the project the firewall rule is related to.
     required: false
     default: null
+  zone:
+    description:
+      - Name of the zone in which the virtual machine is in.
+      - If not set, default zone is used.
+    required: false
+    default: null
   poll_async:
     description:
       - Poll async jobs until job has finished.
@@ -795,6 +801,7 @@ def main():
         start_port = dict(type='int', aliases=['port'], default=None),
         end_port = dict(type='int', default=None),
         state = dict(choices=['present', 'absent'], default='present'),
+        zone = dict(default=None),
         domain = dict(default=None),
         account = dict(default=None),
         project = dict(default=None),


### PR DESCRIPTION
cs_firewall fails to create firewall rule when multiple zones exist because the default region may not have the target ipaddress.
This patch allows users to specify zone by parameter.
