### PR TITLE
Ignore display_volume when account is not Root Admin

### DIFF
--- a/cs_volume.py
+++ b/cs_volume.py
@@ -500,6 +500,13 @@ class AnsibleCloudStack(object):
         self.module.fail_json(msg="Account '%s' not found" % account)
 
 
+    def _get_account_type(self):
+        accounts = self.cs.listAccounts()
+        if accounts:
+            return accounts['account'][0]['accounttype']
+        return None
+
+
     def get_domain(self, key=None):
         if self.domain:
             return self._get_by_key(key, self.domain)
@@ -708,13 +715,16 @@ class AnsibleCloudStackVolume(AnsibleCloudStack):
             args['account'] = self.get_account(key='name')
             args['domainid'] = self.get_domain(key='id')
             args['diskofferingid'] = disk_offering_id
-            args['displayvolume'] = self.module.params.get('display_volume')
             args['maxiops'] = self.module.params.get('max_iops')
             args['miniops'] = self.module.params.get('min_iops')
             args['projectid'] = self.get_project(key='id')
             args['size'] = self.module.params.get('size')
             args['snapshotid'] = snapshot_id
             args['zoneid'] = self.get_zone(key='id')
+
+            # Include displayvolume only when account is Root Admin
+            if self._get_account_type() == 1:
+                args['displayvolume'] = self.module.params.get('display_volume')
 
             if not self.module.check_mode:
                 res = self.cs.createVolume(**args)

--- a/cs_volume.py
+++ b/cs_volume.py
@@ -57,7 +57,7 @@ options:
       - Whether to display the volume to the end user or not.
       - Allowed to Root Admins only.
     required: false
-    default: true
+    default: null
   domain:
     description:
       - Name of the domain the volume to be deployed in.
@@ -500,13 +500,6 @@ class AnsibleCloudStack(object):
         self.module.fail_json(msg="Account '%s' not found" % account)
 
 
-    def _get_account_type(self):
-        accounts = self.cs.listAccounts()
-        if accounts:
-            return accounts['account'][0]['accounttype']
-        return None
-
-
     def get_domain(self, key=None):
         if self.domain:
             return self._get_by_key(key, self.domain)
@@ -715,16 +708,13 @@ class AnsibleCloudStackVolume(AnsibleCloudStack):
             args['account'] = self.get_account(key='name')
             args['domainid'] = self.get_domain(key='id')
             args['diskofferingid'] = disk_offering_id
+            args['displayvolume'] = self.module.params.get('display_volume')
             args['maxiops'] = self.module.params.get('max_iops')
             args['miniops'] = self.module.params.get('min_iops')
             args['projectid'] = self.get_project(key='id')
             args['size'] = self.module.params.get('size')
             args['snapshotid'] = snapshot_id
             args['zoneid'] = self.get_zone(key='id')
-
-            # Include displayvolume only when account is Root Admin
-            if self._get_account_type() == 1:
-                args['displayvolume'] = self.module.params.get('display_volume')
 
             if not self.module.check_mode:
                 res = self.cs.createVolume(**args)
@@ -809,7 +799,7 @@ def main():
     argument_spec.update(dict(
         name = dict(required=True),
         disk_offering = dict(default=None),
-        display_volume = dict(choices=BOOLEANS, default=True),
+        display_volume = dict(choices=BOOLEANS, default=None),
         max_iops = dict(type='int', default=None),
         min_iops = dict(type='int', default=None),
         size = dict(type='int', default=None),


### PR DESCRIPTION
End user and Domain Admin can't create volume using cs_volume because only root admin can use display_volume. The patch checks the account type and ignore display_volume option if the account is not Root Admin. 
