### PR TITLE
Enable to create volumes with the same name on multiple zones

### DIFF
--- a/cs_volume.py
+++ b/cs_volume.py
@@ -665,6 +665,7 @@ class AnsibleCloudStackVolume(AnsibleCloudStack):
             args['account'] = self.get_account(key='name')
             args['domainid'] = self.get_domain(key='id')
             args['projectid'] = self.get_project(key='id')
+            args['zoneid'] = self.get_zone(key='id')
             args['displayvolume'] = self.module.params.get('display_volume')
             args['type'] = 'DATADISK'
 


### PR DESCRIPTION
The commit make get_volume get volumes from only specified zone.
This fix the bug unable to create volumes with the same name on multiple zones.
