### PR TITLE
Python 3 Syntax fixes

### DIFF
--- a/cloudstack-routers.py
+++ b/cloudstack-routers.py
@@ -60,6 +60,7 @@ based on the data obtained from CloudStack API:
 usage: cloudstack-routers.py [--list] [--host HOST]
 """
 
+from __future__ import print_function
 import os
 import sys
 import argparse
@@ -73,7 +74,7 @@ except:
 try:
     from cs import CloudStack, CloudStackException, read_config
 except ImportError:
-    print >> sys.stderr, "Error: CloudStack library must be installed: pip install cs."
+    print("Error: CloudStack library must be installed: pip install cs.", file=sys.stderr)
     sys.exit(1)
 
 
@@ -87,18 +88,18 @@ class CloudStackInventory(object):
         options = parser.parse_args()
         try:
             self.cs = CloudStack(**read_config())
-        except CloudStackException, e:
-            print >> sys.stderr, "Error: Could not connect to CloudStack API"
+        except CloudStackException as e:
+            print("Error: Could not connect to CloudStack API", file=sys.stderr)
 
         if options.host:
             data = self.get_host(options.host)
-            print json.dumps(data, indent=2)
+            print(json.dumps(data, indent=2))
 
         elif options.list:
             data = self.get_list()
-            print json.dumps(data, indent=2)
+            print(json.dumps(data, indent=2))
         else:
-            print >> sys.stderr, "usage: --list | --host <hostname>"
+            print("usage: --list | --host <hostname>", file=sys.stderr)
             sys.exit(1)
 
 

--- a/cloudstack.py
+++ b/cloudstack.py
@@ -70,6 +70,7 @@ based on the data obtained from CloudStack API:
 usage: cloudstack.py [--list] [--host HOST] [--project PROJECT]
 """
 
+from __future__ import print_function
 import os
 import sys
 import argparse
@@ -83,7 +84,7 @@ except:
 try:
     from cs import CloudStack, CloudStackException, read_config
 except ImportError:
-    print >> sys.stderr, "Error: CloudStack library must be installed: pip install cs."
+    print("Error: CloudStack library must be installed: pip install cs.", file=sys.stderr)
     sys.exit(1)
 
 
@@ -98,8 +99,8 @@ class CloudStackInventory(object):
         options = parser.parse_args()
         try:
             self.cs = CloudStack(**read_config())
-        except CloudStackException, e:
-            print >> sys.stderr, "Error: Could not connect to CloudStack API"
+        except CloudStackException as e:
+            print("Error: Could not connect to CloudStack API", file=sys.stderr)
 
         project_id = ''
         if options.project:
@@ -107,13 +108,13 @@ class CloudStackInventory(object):
 
         if options.host:
             data = self.get_host(options.host)
-            print json.dumps(data, indent=2)
+            print(json.dumps(data, indent=2))
 
         elif options.list:
             data = self.get_list()
-            print json.dumps(data, indent=2)
+            print(json.dumps(data, indent=2))
         else:
-            print >> sys.stderr, "usage: --list | --host <hostname> [--project <project>]"
+            print("usage: --list | --host <hostname> [--project <project>]", file=sys.stderr)
             sys.exit(1)
 
 
@@ -123,7 +124,7 @@ class CloudStackInventory(object):
             for p in projects['project']:
                 if p['name'] == project or p['id'] == project:
                     return p['id']
-        print >> sys.stderr, "Error: Project %s not found." % project
+        print("Error: Project %s not found." % project, file=sys.stderr)
         sys.exit(1)
 
 

--- a/cs_account.py
+++ b/cs_account.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -781,7 +781,7 @@ def main():
 
         result = acs_acc.get_result(account)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_affinitygroup.py
+++ b/cs_affinitygroup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -647,7 +647,7 @@ def main():
 
         result = acs_ag.get_result(affinity_group)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_domain.py
+++ b/cs_domain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -659,7 +659,7 @@ def main():
 
         result = acs_dom.get_result(domain)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_facts.py
+++ b/cs_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>

--- a/cs_firewall.py
+++ b/cs_firewall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -841,7 +841,7 @@ def main():
 
         result = acs_fw.get_result(fw_rule)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_instance.py
+++ b/cs_instance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -1322,7 +1322,7 @@ def main():
 
         result = acs_instance.get_result(instance)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_instancegroup.py
+++ b/cs_instancegroup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -590,7 +590,7 @@ def main():
 
         result = acs_ig.get_result(instance_group)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_ip_address.py
+++ b/cs_ip_address.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, Darren Worrall <darren@iweb.co.uk>
@@ -647,7 +647,7 @@ def main():
 
         result = acs_ip_address.get_result(ip_address)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_iso.py
+++ b/cs_iso.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -724,7 +724,7 @@ def main():
 
         result = acs_iso.get_result(iso)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_loadbalancer_rule.py
+++ b/cs_loadbalancer_rule.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, Darren Worrall <darren@iweb.co.uk>
@@ -774,7 +774,7 @@ def main():
 
         result = acs_lb_rule.get_result(rule)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_loadbalancer_rule_member.py
+++ b/cs_loadbalancer_rule_member.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, Darren Worrall <darren@iweb.co.uk>
@@ -749,7 +749,7 @@ def main():
 
         result = acs_lb_rule_member.get_result(rule)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_network.py
+++ b/cs_network.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -969,7 +969,7 @@ def main():
 
         result = acs_network.get_result(network)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_portforward.py
+++ b/cs_portforward.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -796,7 +796,7 @@ def main():
 
         result = acs_pf.get_result(pf_rule)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_project.py
+++ b/cs_project.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -684,7 +684,7 @@ def main():
 
         result = acs_project.get_result(project)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_securitygroup.py
+++ b/cs_securitygroup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -571,7 +571,7 @@ def main():
 
         result = acs_sg.get_result(sg)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_securitygroup_rule.py
+++ b/cs_securitygroup_rule.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -808,7 +808,7 @@ def main():
 
         result = acs_sg_rule.get_result(sg_rule)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_sshkeypair.py
+++ b/cs_sshkeypair.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -632,7 +632,7 @@ def main():
 
         result = acs_sshkey.get_result(ssh_key)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_staticnat.py
+++ b/cs_staticnat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -683,7 +683,7 @@ def main():
 
         result = acs_static_nat.get_result(ip_address)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_template.py
+++ b/cs_template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -986,7 +986,7 @@ def main():
 
         result = acs_tpl.get_result(tpl)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_user.py
+++ b/cs_user.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -840,7 +840,7 @@ def main():
 
         result = acs_acc.get_result(user)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_vmsnapshot.py
+++ b/cs_vmsnapshot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
@@ -689,7 +689,7 @@ def main():
 
         result = acs_vmsnapshot.get_result(snapshot)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)

--- a/cs_volume.py
+++ b/cs_volume.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, Jefferson Girão <jefferson@girao.net>
@@ -879,7 +879,7 @@ def main():
 
         result = acs_vol.get_result(volume)
 
-    except CloudStackException, e:
+    except CloudStackException as e:
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)


### PR DESCRIPTION
`print()` and `except` statements updated to python3 syntax. Also shebangs are now consistently using /usr/bin/env in order to get the python binary. 

Slightly tested, consider some more testing...
