### PR TITLE
cs_instance: do not require name to be set to avoid clashes

### DIFF
--- a/cs_instance.py
+++ b/cs_instance.py
@@ -30,10 +30,15 @@ options:
   name:
     description:
       - Host name of the instance. C(name) can only contain ASCII letters.
-    required: true
+      - Name will be generated (UUID) by CloudStack if not specified and can not be changed afterwards.
+      - Either C(name) or C(display_name) is required.
+    required: false
+    default: null
   display_name:
     description:
       - Custom display name of the instances.
+      - Display name will be set to C(name) if not specified.
+      - Either C(name) or C(display_name) is required.
     required: false
     default: null
   group:
@@ -871,7 +876,7 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
     def get_instance(self):
         instance = self.instance
         if not instance:
-            instance_name = self.module.params.get('name')
+            instance_name = self.get_or_fallback('name', 'display_name')
 
             args                = {}
             args['account']     = self.get_account(key='name')
@@ -1251,7 +1256,7 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
 def main():
     argument_spec = cs_argument_spec()
     argument_spec.update(dict(
-        name = dict(required=True),
+        name = dict(default=None),
         display_name = dict(default=None),
         group = dict(default=None),
         state = dict(choices=['present', 'deployed', 'started', 'stopped', 'restarted', 'restored', 'absent', 'destroyed', 'expunged'], default='present'),
@@ -1291,6 +1296,9 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         required_together=required_together,
+        required_one_of = (
+            ['display_name', 'name'],
+        ),
         mutually_exclusive = (
             ['template', 'iso'],
         ),

--- a/tests/roles/test_cs_instance/tasks/absent.yml
+++ b/tests/roles/test_cs_instance/tasks/absent.yml
@@ -35,3 +35,9 @@
     - instance|changed
     - instance.state == "Stopped"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
+
+# force expunge, only works with admin permissions
+- cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    state: expunged
+  failed_when: false

--- a/tests/roles/test_cs_instance/tasks/absent_display_name.yml
+++ b/tests/roles/test_cs_instance/tasks/absent_display_name.yml
@@ -1,0 +1,43 @@
+---
+- name: test destroy instance with display_name
+  cs_instance:
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    state: absent
+  register: instance
+- name: verify destroy instance with display_name
+  assert:
+    that:
+    - instance|success
+    - instance|changed
+    - instance.state == "Destroyed"
+
+- name: test destroy instance with display_name idempotence
+  cs_instance:
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    state: absent
+  register: instance
+- name: verify destroy instance with display_name idempotence
+  assert:
+    that:
+    - instance|success
+    - not instance|changed
+
+- name: test recover to stopped state and update a deleted instance with display_name
+  cs_instance:
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    service_offering: "{{ test_cs_instance_offering_1 }}"
+    state: stopped
+  register: instance
+- name: verify test recover to stopped state and update a deleted instance with display_name
+  assert:
+    that:
+    - instance|success
+    - instance|changed
+    - instance.state == "Stopped"
+    - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
+
+# force expunge, only works with admin permissions
+- cs_instance:
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    state: expunged
+  failed_when: false

--- a/tests/roles/test_cs_instance/tasks/cleanup.yml
+++ b/tests/roles/test_cs_instance/tasks/cleanup.yml
@@ -1,10 +1,4 @@
 ---
-# force expunge, only works with admin permissions
-- cs_instance:
-    name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
-    state: expunged
-  failed_when: false
-
 - name: cleanup ssh key
   cs_sshkeypair: name={{ cs_resource_prefix }}-sshkey state=absent
   register: sshkey

--- a/tests/roles/test_cs_instance/tasks/main.yml
+++ b/tests/roles/test_cs_instance/tasks/main.yml
@@ -4,3 +4,8 @@
 - include: tags.yml
 - include: absent.yml
 - include: cleanup.yml
+
+- include: setup.yml
+- include: present_display_name.yml
+- include: absent_display_name.yml
+- include: cleanup.yml

--- a/tests/roles/test_cs_instance/tasks/present_display_name.yml
+++ b/tests/roles/test_cs_instance/tasks/present_display_name.yml
@@ -1,15 +1,15 @@
 ---
-- name: setup instance to be absent
-  cs_instance: name={{ cs_resource_prefix }}-vm-{{ instance_number }} state=absent
+- name: setup instance with display_name to be absent
+  cs_instance: display_name={{ cs_resource_prefix }}-vm-{{ instance_number }} state=absent
   register: instance
-- name: verify instance to be absent
+- name: verify instance with display_name to be absent
   assert:
     that:
     - instance|success
 
-- name: test create instance
+- name: test create instance with display_name
   cs_instance:
-    name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     template: "{{ test_cs_instance_template }}"
     service_offering: "{{ test_cs_instance_offering_1 }}"
     affinity_group: "{{ cs_resource_prefix }}-ag"
@@ -17,21 +17,20 @@
     ssh_key: "{{ cs_resource_prefix }}-sshkey"
     tags: []
   register: instance
-- name: verify create instance
+- name: verify create instance with display_name
   assert:
     that:
     - instance|success
     - instance|changed
-    - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
     - instance.state == "Running"
     - instance.ssh_key == "{{ cs_resource_prefix }}-sshkey"
     - not instance.tags
 
-- name: test create instance idempotence
+- name: test create instance with display_name idempotence
   cs_instance:
-    name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     template: "{{ test_cs_instance_template }}"
     service_offering: "{{ test_cs_instance_offering_1 }}"
     affinity_group: "{{ cs_resource_prefix }}-ag"
@@ -39,51 +38,48 @@
     ssh_key: "{{ cs_resource_prefix }}-sshkey"
     tags: []
   register: instance
-- name: verify create instance idempotence
+- name: verify create instance with display_name idempotence
   assert:
     that:
     - instance|success
     - not instance|changed
-    - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
     - instance.state == "Running"
     - instance.ssh_key == "{{ cs_resource_prefix }}-sshkey"
     - not instance.tags
 
-- name: test running instance not updated
+- name: test running instance with display_name not updated
   cs_instance:
-    name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     service_offering: "{{ test_cs_instance_offering_2 }}"
   register: instance
-- name: verify running instance not updated
+- name: verify running instance with display_name not updated
   assert:
     that:
     - instance|success
     - not instance|changed
-    - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
     - instance.state == "Running"
 
-- name: test stopping instance
+- name: test stopping instance with display_name
   cs_instance:
-    name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     state: stopped
   register: instance
-- name: verify stopping instance
+- name: verify stopping instance with display_name
   assert:
     that:
     - instance|success
     - instance|changed
-    - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
     - instance.state == "Stopped"
 
-- name: test stopping instance idempotence
+- name: test stopping instance with display_name idempotence
   cs_instance:
-    name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     state: stopped
   register: instance
 - name: verify stopping instance idempotence
@@ -93,95 +89,88 @@
     - not instance|changed
     - instance.state == "Stopped"
 
-- name: test updating stopped instance
+- name: test updating stopped instance with display_name
   cs_instance:
-    name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
-    display_name: "{{ cs_resource_prefix }}-display-{{ instance_number }}"
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     service_offering: "{{ test_cs_instance_offering_2 }}"
   register: instance
-- name: verify updating stopped instance
+- name: verify updating stopped instance with display_name
   assert:
     that:
     - instance|success
     - instance|changed
-    - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
-    - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
+    - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_2 }}"
     - instance.state == "Stopped"
 
-- name: test starting instance
+- name: test starting instance with display_name
   cs_instance:
-    name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     state: started
   register: instance
-- name: verify starting instance
+- name: verify starting instance with display_name
   assert:
     that:
     - instance|success
     - instance|changed
-    - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
-    - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
+    - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_2 }}"
     - instance.state == "Running"
 
-- name: test starting instance idempotence
+- name: test starting instance with display_name idempotence
   cs_instance:
-    name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     state: started
   register: instance
-- name: verify starting instance idempotence
+- name: verify starting instance with display_name idempotence
   assert:
     that:
     - instance|success
     - not instance|changed
-    - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
-    - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
+    - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_2 }}"
     - instance.state == "Running"
 
-- name: test force update running instance
+- name: test force update running instance with display_name
   cs_instance:
-    name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     service_offering: "{{ test_cs_instance_offering_1 }}"
     force: true
   register: instance
-- name: verify force update running instance
+- name: verify force update running instance with display_name
   assert:
     that:
     - instance|success
     - instance|changed
-    - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
-    - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
+    - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
     - instance.state == "Running"
 
-- name: test force update running instance idempotence
+- name: test force update running instance with display_name idempotence
   cs_instance:
-    name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     service_offering: "{{ test_cs_instance_offering_1 }}"
     force: true
   register: instance
-- name: verify force update running instance idempotence
+- name: verify force update running instance with display_name idempotence
   assert:
     that:
     - instance|success
     - not instance|changed
-    - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
-    - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
+    - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
     - instance.state == "Running"
 
-- name: test restore instance
+- name: test restore instance with display_name
   cs_instance:
-    name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
+    display_name: "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     template: "{{ test_cs_instance_template }}"
     state: restored
   register: instance
-- name: verify restore instance
+- name: verify restore instance with display_name
   assert:
     that:
     - instance|success
     - instance|changed
-    - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
-    - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
+    - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"

--- a/tests/roles/test_cs_instance/tasks/setup.yml
+++ b/tests/roles/test_cs_instance/tasks/setup.yml
@@ -22,11 +22,3 @@
   assert:
     that:
     - sg|success
-
-- name: setup instance to be absent
-  cs_instance: name={{ cs_resource_prefix }}-vm-{{ instance_number }} state=absent
-  register: instance
-- name: verify instance to be absent
-  assert:
-    that:
-    - instance|success


### PR DESCRIPTION
closes #37
Tests results https://build.ngine.io/job/ansible.8086.resmo.ansible-cloudstack.cloudstack-basic-4.5-devel/33 extended and passed.
@pyr @llambiel
